### PR TITLE
[Fix] Fetch Splat by Id in Viewer

### DIFF
--- a/app/api/fetchSceneDetailsWithID/route.ts
+++ b/app/api/fetchSceneDetailsWithID/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+import { db } from '../../db/db';
+import { splats } from '../../db/schema';
+import { eq } from 'drizzle-orm';
+import type { InferSelectModel } from 'drizzle-orm';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+
+// app/api/fetchSceneDetailsWithID/route.ts
+interface SceneItem {
+  id?: number;
+  src: string;
+  splatSrc: string;
+  name: string | null;
+  description: string | null;
+}
+
+// Replace DbItem with inferred type
+type DbItem = InferSelectModel<typeof splats>;
+
+export async function GET(
+  { params }: { params: { id: string } }
+) {
+  try {
+    const id = parseInt(params.id);
+    const dbData: DbItem[] = await db.select()
+      .from(splats)
+      .where(eq(splats.id, id));
+
+      if (!dbData.length) {
+        return NextResponse.json(
+          { error: 'Item not found' },
+          { status: 404 }
+        );
+      }
+
+      const item = dbData[0];
+      const sceneItem: SceneItem = {
+        id: item.id,
+        src: item.video || '',
+        splatSrc: item.splat || '',
+        name: item.name || 'Untitled',
+        description: item.description || 'No description available'
+      };
+  
+
+      return NextResponse.json(sceneItem, {
+        headers: {
+          'Cache-Control': 'no-store, must-revalidate',
+          'Pragma': 'no-cache',
+          'Expires': '0',
+        }
+    });
+  } catch (error) {
+    console.error("Error fetching video items:", error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/app/api/fetchSceneDetailsWithID/route.ts
+++ b/app/api/fetchSceneDetailsWithID/route.ts
@@ -19,11 +19,19 @@ interface SceneItem {
 // Replace DbItem with inferred type
 type DbItem = InferSelectModel<typeof splats>;
 
-export async function GET(
-  { params }: { params: { id: string } }
-) {
+export async function GET(request: Request) {
   try {
-    const id = parseInt(params.id);
+    const { searchParams } = new URL(request.url);
+    let rawId: string | null = searchParams.get('id');
+    
+    if (!rawId) {
+      return NextResponse.json(
+        { error: 'Id does not exist' },
+        { status: 404 }
+      );
+    }
+
+    const id = parseInt(rawId);
     const dbData: DbItem[] = await db.select()
       .from(splats)
       .where(eq(splats.id, id));

--- a/app/api/fetchSceneDetailsWithID/route.ts
+++ b/app/api/fetchSceneDetailsWithID/route.ts
@@ -22,7 +22,7 @@ type DbItem = InferSelectModel<typeof splats>;
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    let rawId: string | null = searchParams.get('id');
+    const rawId: string | null = searchParams.get('id');
     
     if (!rawId) {
       return NextResponse.json(

--- a/app/components/MasonryGrid.tsx
+++ b/app/components/MasonryGrid.tsx
@@ -87,9 +87,7 @@ export default function MasonryGrid() {
     console.log("Sending item:", item);
     if (item.splatSrc) {
       const url = `/viewer?${new URLSearchParams({
-        splatUrl: item.splatSrc,
-        description: item.description || '',
-        name: item.name || '',
+        id: item.id.toString()
       })}`;
       console.log("Navigation URL:", url);
       router.push(url);

--- a/app/viewer/components/SplatViewer.tsx
+++ b/app/viewer/components/SplatViewer.tsx
@@ -14,10 +14,7 @@ import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 interface SplatViewerProps {
-  // splatUrl: string | null;
   onClose: () => void;
-  // description?: string;
-  // name?: string;
   id?: number;
 }
 
@@ -29,15 +26,12 @@ interface SceneItem {
 }
 
 export default function SplatViewer({ 
-  // splatUrl, 
-  onClose, 
-  // description = "", 
-  // name = "",
+  onClose,
   id = 1,
 }: SplatViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<OrbitControlsImpl>(null);
-  // const [loading, setLoading] = useState(false);
+  // const [loading, setLoading] = useState(false); // For future use
   const [sceneItem, setSceneItem] = useState<SceneItem[]>([]);
   const [showInfo, setShowInfo] = useState(false);
 
@@ -45,9 +39,9 @@ export default function SplatViewer({
     const fetchSceneItem = async () => {
       // setLoading(true);
       try {
-        const response = await fetch('api/fetchSceneDetailsWithID' + new URLSearchParams({
+        const response = await fetch(`api/fetchSceneDetailsWithID?${new URLSearchParams({
           id: id.toString(),
-        }).toString());
+        }).toString()}`);
         const sceneItem: SceneItem = await response.json().then(async (item) => {
           return {
             id: item.id,
@@ -64,7 +58,7 @@ export default function SplatViewer({
       }
     };
     fetchSceneItem();
-  }, [sceneItem, id]);
+  }, []);
 
   const getSignedS3Url = async (s3Url: string) => {
     if (!s3Url) return null;
@@ -114,7 +108,7 @@ export default function SplatViewer({
   // Create GridHelper using useMemo to prevent re-creation on every render
   const gridHelper = useMemo(() => new THREE.GridHelper(100, 100, 'white', 'gray'), []);
 
-  if (!sceneItem[0].splatUrl) {
+  if (!sceneItem.length || !sceneItem[0].splatUrl) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
         <div className="text-center">

--- a/app/viewer/components/SplatViewer.tsx
+++ b/app/viewer/components/SplatViewer.tsx
@@ -1,6 +1,6 @@
 // app/viewer/components/SplatViewer.tsx
 'use client';
-import React, { useRef, useCallback, useMemo, useState } from 'react';
+import React, { useRef, useCallback, useMemo, useState, useEffect } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Stats, PerspectiveCamera, Html } from '@react-three/drei';
 import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
@@ -10,23 +10,100 @@ import { SceneSetup } from './SceneSetup';
 import * as THREE from 'three'; 
 import { ErrorBoundary } from 'react-error-boundary';
 import { InfoPanel } from './InfoPanel';
+import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 interface SplatViewerProps {
-  splatUrl: string | null;
+  // splatUrl: string | null;
   onClose: () => void;
-  description?: string;
-  name?: string;
+  // description?: string;
+  // name?: string;
+  id?: number;
+}
+
+interface SceneItem {
+  id: number;
+  name: string | null;
+  description: string | null;
+  splatUrl: string | null;
 }
 
 export default function SplatViewer({ 
-  splatUrl, 
+  // splatUrl, 
   onClose, 
-  description = "", 
-  name = "" 
+  // description = "", 
+  // name = "",
+  id = 1,
 }: SplatViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<OrbitControlsImpl>(null);
+  // const [loading, setLoading] = useState(false);
+  const [sceneItem, setSceneItem] = useState<SceneItem[]>([]);
   const [showInfo, setShowInfo] = useState(false);
+
+  useEffect(() => {
+    const fetchSceneItem = async () => {
+      // setLoading(true);
+      try {
+        const response = await fetch('api/fetchSceneDetailsWithID' + new URLSearchParams({
+          id: id.toString(),
+        }).toString());
+        const sceneItem: SceneItem = await response.json().then(async (item) => {
+          return {
+            id: item.id,
+            name: item.name,
+            description: item.description,
+            splatUrl: await getSignedS3Url(item.splatSrc)
+          }
+        });
+        setSceneItem([sceneItem]);
+      } catch (error) {
+        console.error("Error fetching scene items:", error);
+      } finally {
+        // setLoading(false);
+      }
+    };
+    fetchSceneItem();
+  }, [sceneItem, id]);
+
+  const getSignedS3Url = async (s3Url: string) => {
+    if (!s3Url) return null;
+    
+    const s3Client = new S3Client({
+      region: process.env.NEXT_PUBLIC_AWS_REGION!,
+      credentials: {
+        accessKeyId: process.env.NEXT_PUBLIC_AWS_ACCESS_KEY_ID!,
+        secretAccessKey: process.env.NEXT_PUBLIC_AWS_SECRET_ACCESS_KEY!,
+      },
+    });
+
+    let bucketName = process.env.NEXT_PUBLIC_AWS_BUCKET_NAME!;
+    let objectKey = '';
+
+    // Handle different URL formats
+    if (s3Url.startsWith('s3://')) {
+      const bucketAndKey = s3Url.substring(5); // Remove 's3://'
+      const [bucket, ...keyParts] = bucketAndKey.split('/');
+      bucketName = bucket;
+      objectKey = keyParts.join('/');
+    } else if (s3Url.startsWith('https://')) {
+      // Handle full HTTPS URL
+      const url = new URL(s3Url);
+      bucketName = url.hostname.split('.')[0];
+      objectKey = url.pathname.substring(1); // Remove leading '/'
+    } else {
+      // Handle plain object key
+      objectKey = s3Url;
+    }
+
+    const command = new GetObjectCommand({ Bucket: bucketName, Key: objectKey });
+    try {
+      return await getSignedUrl(s3Client, command, { expiresIn: 3600 });
+    } catch (error) {
+      console.error("Error generating presigned URL:", error);
+      return null;
+    }
+  };
 
   const handleReset = useCallback(() => {
     if (controlsRef.current) {
@@ -37,7 +114,7 @@ export default function SplatViewer({
   // Create GridHelper using useMemo to prevent re-creation on every render
   const gridHelper = useMemo(() => new THREE.GridHelper(100, 100, 'white', 'gray'), []);
 
-  if (!splatUrl) {
+  if (!sceneItem[0].splatUrl) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
         <div className="text-center">
@@ -58,8 +135,8 @@ export default function SplatViewer({
         onInfoClick={() => setShowInfo(true)}
       />
       <InfoPanel 
-        description={description}
-        name={name}
+        description={sceneItem[0].description ||  ''}
+        name={sceneItem[0].name || ''}
         isOpen={showInfo}
         onClose={() => setShowInfo(false)}
       />
@@ -90,7 +167,7 @@ export default function SplatViewer({
             minPolarAngle={Math.PI * 0.25}
             target={[0, 0, 0]}
           />
-          <SceneSetup splatUrl={splatUrl} />
+          <SceneSetup splatUrl={sceneItem[0].splatUrl || ''} />
           <primitive object={gridHelper} />
         </ErrorBoundary>
       </Canvas>

--- a/app/viewer/components/SplatViewer.tsx
+++ b/app/viewer/components/SplatViewer.tsx
@@ -72,7 +72,7 @@ export default function SplatViewer({ onClose, id }: SplatViewerProps) {
       }
     };
     fetchSceneItem();
-  }, []);
+  }, [id]);
 
   const getSignedS3Url = async (s3Url: string) => {
     if (!s3Url) return null;

--- a/app/viewer/components/SplatViewer.tsx
+++ b/app/viewer/components/SplatViewer.tsx
@@ -1,21 +1,32 @@
 // app/viewer/components/SplatViewer.tsx
-'use client';
-import React, { useRef, useCallback, useMemo, useState, useEffect } from 'react';
-import { Canvas } from '@react-three/fiber';
-import { OrbitControls, Stats, PerspectiveCamera, Html } from '@react-three/drei';
-import type { OrbitControls as OrbitControlsImpl } from 'three-stdlib';
-import { CameraController } from './CameraController';
-import { ControlsUI } from './ControlsUI';
-import { SceneSetup } from './SceneSetup';
-import * as THREE from 'three'; 
-import { ErrorBoundary } from 'react-error-boundary';
-import { InfoPanel } from './InfoPanel';
+"use client";
+import React, {
+  useRef,
+  useCallback,
+  useMemo,
+  useState,
+  useEffect,
+} from "react";
+import { Canvas } from "@react-three/fiber";
+import {
+  OrbitControls,
+  Stats,
+  PerspectiveCamera,
+  Html,
+} from "@react-three/drei";
+import type { OrbitControls as OrbitControlsImpl } from "three-stdlib";
+import { CameraController } from "./CameraController";
+import { ControlsUI } from "./ControlsUI";
+import { SceneSetup } from "./SceneSetup";
+import * as THREE from "three";
+import { ErrorBoundary } from "react-error-boundary";
+import { InfoPanel } from "./InfoPanel";
 import { S3Client, GetObjectCommand } from "@aws-sdk/client-s3";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
 
 interface SplatViewerProps {
   onClose: () => void;
-  id?: number;
+  id: string | null;
 }
 
 interface SceneItem {
@@ -25,36 +36,39 @@ interface SceneItem {
   splatUrl: string | null;
 }
 
-export default function SplatViewer({ 
-  onClose,
-  id = 1,
-}: SplatViewerProps) {
+export default function SplatViewer({ onClose, id }: SplatViewerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const controlsRef = useRef<OrbitControlsImpl>(null);
-  // const [loading, setLoading] = useState(false); // For future use
+  const [loading, setLoading] = useState(false); // For future use
   const [sceneItem, setSceneItem] = useState<SceneItem[]>([]);
   const [showInfo, setShowInfo] = useState(false);
 
   useEffect(() => {
     const fetchSceneItem = async () => {
-      // setLoading(true);
-      try {
-        const response = await fetch(`api/fetchSceneDetailsWithID?${new URLSearchParams({
-          id: id.toString(),
-        }).toString()}`);
-        const sceneItem: SceneItem = await response.json().then(async (item) => {
-          return {
-            id: item.id,
-            name: item.name,
-            description: item.description,
-            splatUrl: await getSignedS3Url(item.splatSrc)
-          }
-        });
-        setSceneItem([sceneItem]);
-      } catch (error) {
-        console.error("Error fetching scene items:", error);
-      } finally {
-        // setLoading(false);
+      setLoading(true);
+      if (id) {
+        try {
+          const response = await fetch(
+            `api/fetchSceneDetailsWithID?${new URLSearchParams({
+              id: id,
+            }).toString()}`
+          );
+          const sceneItem: SceneItem = await response
+            .json()
+            .then(async (item) => {
+              return {
+                id: item.id,
+                name: item.name,
+                description: item.description,
+                splatUrl: await getSignedS3Url(item.splatSrc),
+              };
+            });
+          setSceneItem([sceneItem]);
+        } catch (error) {
+          console.error("Error fetching scene items:", error);
+        } finally {
+          setLoading(false); // If possible, hide loader after scene has completed rendering
+        }
       }
     };
     fetchSceneItem();
@@ -62,7 +76,7 @@ export default function SplatViewer({
 
   const getSignedS3Url = async (s3Url: string) => {
     if (!s3Url) return null;
-    
+
     const s3Client = new S3Client({
       region: process.env.NEXT_PUBLIC_AWS_REGION!,
       credentials: {
@@ -72,25 +86,28 @@ export default function SplatViewer({
     });
 
     let bucketName = process.env.NEXT_PUBLIC_AWS_BUCKET_NAME!;
-    let objectKey = '';
+    let objectKey = "";
 
     // Handle different URL formats
-    if (s3Url.startsWith('s3://')) {
+    if (s3Url.startsWith("s3://")) {
       const bucketAndKey = s3Url.substring(5); // Remove 's3://'
-      const [bucket, ...keyParts] = bucketAndKey.split('/');
+      const [bucket, ...keyParts] = bucketAndKey.split("/");
       bucketName = bucket;
-      objectKey = keyParts.join('/');
-    } else if (s3Url.startsWith('https://')) {
+      objectKey = keyParts.join("/");
+    } else if (s3Url.startsWith("https://")) {
       // Handle full HTTPS URL
       const url = new URL(s3Url);
-      bucketName = url.hostname.split('.')[0];
+      bucketName = url.hostname.split(".")[0];
       objectKey = url.pathname.substring(1); // Remove leading '/'
     } else {
       // Handle plain object key
       objectKey = s3Url;
     }
 
-    const command = new GetObjectCommand({ Bucket: bucketName, Key: objectKey });
+    const command = new GetObjectCommand({
+      Bucket: bucketName,
+      Key: objectKey,
+    });
     try {
       return await getSignedUrl(s3Client, command, { expiresIn: 3600 });
     } catch (error) {
@@ -106,14 +123,30 @@ export default function SplatViewer({
   }, []);
 
   // Create GridHelper using useMemo to prevent re-creation on every render
-  const gridHelper = useMemo(() => new THREE.GridHelper(100, 100, 'white', 'gray'), []);
+  const gridHelper = useMemo(
+    () => new THREE.GridHelper(100, 100, "white", "gray"),
+    []
+  );
+
+  if (loading) {
+    return (
+      <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
+        <div className="text-center">
+          <p>Fetching Splat....</p>
+        </div>
+      </div>
+    );
+  }
 
   if (!sceneItem.length || !sceneItem[0].splatUrl) {
     return (
       <div className="fixed inset-0 bg-black flex items-center justify-center z-50">
         <div className="text-center">
           <p>No Splat to display.</p>
-          <button onClick={onClose} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+          <button
+            onClick={onClose}
+            className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+          >
             Go Home
           </button>
         </div>
@@ -123,24 +156,27 @@ export default function SplatViewer({
 
   return (
     <div ref={containerRef} className="fixed inset-0 bg-black z-50">
-      <ControlsUI 
-        onReset={handleReset} 
-        onClose={onClose} 
+      <ControlsUI
+        onReset={handleReset}
+        onClose={onClose}
         onInfoClick={() => setShowInfo(true)}
       />
-      <InfoPanel 
-        description={sceneItem[0].description ||  ''}
-        name={sceneItem[0].name || ''}
+      <InfoPanel
+        description={sceneItem[0].description || ""}
+        name={sceneItem[0].name || ""}
         isOpen={showInfo}
         onClose={() => setShowInfo(false)}
       />
       <Canvas>
-        <ErrorBoundary 
+        <ErrorBoundary
           fallback={
             <Html center>
               <div className="text-center">
                 <p className="text-red-500">Failed to load Splat</p>
-                <button onClick={onClose} className="mt-4 px-4 py-2 bg-blue-500 text-white rounded">
+                <button
+                  onClick={onClose}
+                  className="mt-4 px-4 py-2 bg-blue-500 text-white rounded"
+                >
                   Go Home
                 </button>
               </div>
@@ -148,7 +184,13 @@ export default function SplatViewer({
           }
         >
           <Stats />
-          <PerspectiveCamera makeDefault position={[0.40, 0.08, -0.42]} fov={75} near={0.1} far={1000} />
+          <PerspectiveCamera
+            makeDefault
+            position={[0.4, 0.08, -0.42]}
+            fov={75}
+            near={0.1}
+            far={1000}
+          />
           <CameraController />
           <OrbitControls
             ref={controlsRef}
@@ -161,7 +203,7 @@ export default function SplatViewer({
             minPolarAngle={Math.PI * 0.25}
             target={[0, 0, 0]}
           />
-          <SceneSetup splatUrl={sceneItem[0].splatUrl || ''} />
+          <SceneSetup splatUrl={sceneItem[0].splatUrl || ""} />
           <primitive object={gridHelper} />
         </ErrorBoundary>
       </Canvas>

--- a/app/viewer/page.tsx
+++ b/app/viewer/page.tsx
@@ -1,13 +1,13 @@
 // app/viewer/page.tsx
-'use client';
-import React, { useEffect, Suspense } from 'react';
-import { useSearchParams, useRouter } from 'next/navigation';
-import type { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import SplatViewer from './components/SplatViewer';
+"use client";
+import React, { useEffect, Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import type { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
+import SplatViewer from "./components/SplatViewer";
 
 const Viewer: React.FC = () => {
   const router = useRouter();
-  
+
   return (
     <Suspense fallback={<div>Loading...</div>}>
       <ViewerContent router={router} />
@@ -21,30 +21,32 @@ interface ViewerContentProps {
 
 const ViewerContent: React.FC<ViewerContentProps> = ({ router }) => {
   const searchParams = useSearchParams();
-  const splatUrl = searchParams.get('splatUrl');
-  const description = searchParams.get('description');
-  const name = searchParams.get('name');
+  const id = searchParams.get("id");
+  const splatUrl = searchParams.get("splatUrl");
+  const description = searchParams.get("description");
+  const name = searchParams.get("name");
 
   useEffect(() => {
     if (splatUrl) {
-      console.log("Params received:", { 
-        splatUrl, 
-        description, 
-        name 
+      console.log("Params received:", {
+        id,
+        splatUrl,
+        description,
+        name,
       });
     }
-  }, [splatUrl, description, name]);
+  }, [id, splatUrl, description, name]);
 
   const handleClose = () => {
-    router.push('/');
+    router.push("/");
   };
 
   return (
-    <SplatViewer 
+    <SplatViewer
       // splatUrl={splatUrl ? decodeURIComponent(splatUrl) : null}
       // description={description ? decodeURIComponent(description) : 'No description available'}
       // name={name ? decodeURIComponent(name) : 'Untitled'}
-      id={1}
+      id={id}
       onClose={handleClose}
     />
   );

--- a/app/viewer/page.tsx
+++ b/app/viewer/page.tsx
@@ -41,9 +41,10 @@ const ViewerContent: React.FC<ViewerContentProps> = ({ router }) => {
 
   return (
     <SplatViewer 
-      splatUrl={splatUrl ? decodeURIComponent(splatUrl) : null}
-      description={description ? decodeURIComponent(description) : 'No description available'}
-      name={name ? decodeURIComponent(name) : 'Untitled'}
+      // splatUrl={splatUrl ? decodeURIComponent(splatUrl) : null}
+      // description={description ? decodeURIComponent(description) : 'No description available'}
+      // name={name ? decodeURIComponent(name) : 'Untitled'}
+      id={1}
       onClose={handleClose}
     />
   );


### PR DESCRIPTION
Added code to fetch Splat by id in Viewer.

- MasonryGrid's `handleVideoClick` handler updated to only pass `id` to Viewer route.
- SplatViewer updated with logic to load `SceneItem` data from database via `id`.