### PR TITLE
Fix-s3-migrate (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Database Code refactor 
+- Gallery splat API now returns pre-signed video and splat URLs; gallery thumbnails are pre-signed via the galleries listing endpoint
+- The database will be storing the S3 keys instead of the full path to support dynamic URL signing and easier migration between storage buckets
 
 ## [0.2.1] - 2025-02-04
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,23 @@ npx drizzle-kit migrate
 ### Asset Storage
 - Currently configured for S3 URLs
 - Viewer supports any public URL (upcoming feature)
+- The database will be storing the S3 keys instead of the full path to support dynamic URL signing and easier migration between storage buckets
+
+#### S3 Multipart Upload CORS
+Multipart uploads rely on reading the ETag from each presigned `PUT` response. Update your bucket CORS rule to expose that header:
+
+```json
+[
+  {
+    "AllowedHeaders": ["*"],
+    "AllowedMethods": ["GET", "PUT", "POST"],
+    "AllowedOrigins": ["*"],
+    "ExposeHeaders": ["ETag"]
+  }
+]
+```
+
+After saving the policy, wait for it to propagate and verify in your browser devtools that each part response now includes the `ETag` header before calling the completion endpoint.
 
 ### Framework
 - [Next.js](https://nextjs.org)

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,11 +2,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    remotePatterns: [{
-      protocol: 'https',
-      hostname: 'diffstudio-assets.s3.us-east-2.amazonaws.com',
-      port: '',
-      pathname: '/**'
+    remotePatterns: [
+    {
+      protocol: "https",
+      hostname: "gaussian-galleria-assets.s3.us-east-2.amazonaws.com",
+      pathname: "/**",
     }],
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,13 +1694,10 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.0.tgz",
-      "integrity": "sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==",
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.3.tgz",
+      "integrity": "sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==",
       "license": "MIT",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -2072,9 +2069,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.23.tgz",
-      "integrity": "sha512-CysUC9IO+2Bh0omJ3qrb47S8DtsTKbFidGm6ow4gXIG6reZybqxbkH2nhdEm1tC8SmgzDdpq3BIML0PWsmyUYA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.32.tgz",
+      "integrity": "sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -2088,12 +2085,13 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.23.tgz",
-      "integrity": "sha512-WhtEntt6NcbABA8ypEoFd3uzq5iAnrl9AnZt9dXdO+PZLACE32z3a3qA5OoV20JrbJfSJ6Sd6EqGZTrlRnGxQQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.32.tgz",
+      "integrity": "sha512-osHXveM70zC+ilfuFa/2W6a1XQxJTvEhzEycnjUaVE8kpUS09lDpiDDX2YLdyFCzoUbvbo5r0X1Kp4MllIOShw==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2103,12 +2101,13 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.23.tgz",
-      "integrity": "sha512-vwLw0HN2gVclT/ikO6EcE+LcIN+0mddJ53yG4eZd0rXkuEr/RnOaMH8wg/sYl5iz5AYYRo/l6XX7FIo6kwbw1Q==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.32.tgz",
+      "integrity": "sha512-P9NpCAJuOiaHHpqtrCNncjqtSBi1f6QUdHK/+dNabBIXB2RUFWL19TY1Hkhu74OvyNQEYEzzMJCMQk5agjw1Qg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -2118,12 +2117,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.23.tgz",
-      "integrity": "sha512-uuAYwD3At2fu5CH1wD7FpP87mnjAv4+DNvLaR9kiIi8DLStWSW304kF09p1EQfhcbUI1Py2vZlBO2VaVqMRtpg==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.32.tgz",
+      "integrity": "sha512-v7JaO0oXXt6d+cFjrrKqYnR2ubrD+JYP7nQVRZgeo5uNE5hkCpWnHmXm9vy3g6foMO8SPwL0P3MPw1c+BjbAzA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2133,12 +2133,13 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.23.tgz",
-      "integrity": "sha512-Mm5KHd7nGgeJ4EETvVgFuqKOyDh+UMXHXxye6wRRFDr4FdVRI6YTxajoV2aHE8jqC14xeAMVZvLqYqS7isHL+g==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.32.tgz",
+      "integrity": "sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2148,9 +2149,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.23.tgz",
-      "integrity": "sha512-Ybfqlyzm4sMSEQO6lDksggAIxnvWSG2cDWnG2jgd+MLbHYn2pvFA8DQ4pT2Vjk3Cwrv+HIg7vXJ8lCiLz79qoQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.32.tgz",
+      "integrity": "sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==",
       "cpu": [
         "x64"
       ],
@@ -2164,12 +2165,13 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.23.tgz",
-      "integrity": "sha512-OSQX94sxd1gOUz3jhhdocnKsy4/peG8zV1HVaW6DLEbEmRRtUCUQZcKxUD9atLYa3RZA+YJx+WZdOnTkDuNDNA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.32.tgz",
+      "integrity": "sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -2179,12 +2181,13 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.23.tgz",
-      "integrity": "sha512-ezmbgZy++XpIMTcTNd0L4k7+cNI4ET5vMv/oqNfTuSXkZtSA9BURElPFyarjjGtRgZ9/zuKDHoMdZwDZIY3ehQ==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.32.tgz",
+      "integrity": "sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2194,12 +2197,13 @@
       }
     },
     "node_modules/@next/swc-win32-ia32-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.23.tgz",
-      "integrity": "sha512-zfHZOGguFCqAJ7zldTKg4tJHPJyJCOFhpoJcVxKL9BSUHScVDnMdDuOU1zPPGdOzr/GWxbhYTjyiEgLEpAoFPA==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.32.tgz",
+      "integrity": "sha512-jHUeDPVHrgFltqoAqDB6g6OStNnFxnc7Aks3p0KE0FbwAvRg6qWKYF5mSTdCTxA3axoSAUwxYdILzXJfUwlHhA==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2209,12 +2213,13 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.23.tgz",
-      "integrity": "sha512-xCtq5BD553SzOgSZ7UH5LH+OATQihydObTrCTvVzOro8QiWYKdBVwcB2Mn2MLMo6DGW9yH1LSPw7jS7HhgJgjw==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.32.tgz",
+      "integrity": "sha512-2N0lSoU4GjfLSO50wvKpMQgKd4HdI2UHEhQPPPnlgfBJlOgJxkjpkYBqzk08f1gItBB6xF/n+ykso2hgxuydsA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -3467,9 +3472,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3963,9 +3968,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4109,9 +4114,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001692",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001692.tgz",
-      "integrity": "sha512-A95VKan0kdtrsnMubMKxEKUKImOPSuCpYgxSQBo036P5YYgVIcOYJEgt/txJWqObiRQeISNCfef9nvlQ0vbV7A==",
+      "version": "1.0.30001736",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001736.tgz",
+      "integrity": "sha512-ImpN5gLEY8gWeqfLUyEF4b7mYWcYoR2Si1VhnrbM4JizRFmfGaAQ12PhNykq6nvI4XvKLrsp8Xde74D5phJOSw==",
       "funding": [
         {
           "type": "opencollective",
@@ -5700,9 +5705,9 @@
       }
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6792,12 +6797,12 @@
       "license": "MIT"
     },
     "node_modules/next": {
-      "version": "14.2.23",
-      "resolved": "https://registry.npmjs.org/next/-/next-14.2.23.tgz",
-      "integrity": "sha512-mjN3fE6u/tynneLiEg56XnthzuYw+kD7mCujgVqioxyPqbmiotUCGJpIZGS/VaPg3ZDT1tvWxiVyRzeqJFm/kw==",
+      "version": "14.2.32",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.32.tgz",
+      "integrity": "sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "14.2.23",
+        "@next/env": "14.2.32",
         "@swc/helpers": "0.5.5",
         "busboy": "1.6.0",
         "caniuse-lite": "^1.0.30001579",
@@ -6812,15 +6817,15 @@
         "node": ">=18.17.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "14.2.23",
-        "@next/swc-darwin-x64": "14.2.23",
-        "@next/swc-linux-arm64-gnu": "14.2.23",
-        "@next/swc-linux-arm64-musl": "14.2.23",
-        "@next/swc-linux-x64-gnu": "14.2.23",
-        "@next/swc-linux-x64-musl": "14.2.23",
-        "@next/swc-win32-arm64-msvc": "14.2.23",
-        "@next/swc-win32-ia32-msvc": "14.2.23",
-        "@next/swc-win32-x64-msvc": "14.2.23"
+        "@next/swc-darwin-arm64": "14.2.32",
+        "@next/swc-darwin-x64": "14.2.32",
+        "@next/swc-linux-arm64-gnu": "14.2.32",
+        "@next/swc-linux-arm64-musl": "14.2.32",
+        "@next/swc-linux-x64-gnu": "14.2.32",
+        "@next/swc-linux-x64-musl": "14.2.32",
+        "@next/swc-win32-arm64-msvc": "14.2.32",
+        "@next/swc-win32-ia32-msvc": "14.2.32",
+        "@next/swc-win32-x64-msvc": "14.2.32"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -7655,12 +7660,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
-      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.3",

--- a/src/app/(views)/admin/dashboard/modalViews/EditSplatModal.tsx
+++ b/src/app/(views)/admin/dashboard/modalViews/EditSplatModal.tsx
@@ -37,7 +37,7 @@ export default function EditSplatModal({
       if (splatFile.size > 0) {
         const result = await handleMultipartUpload(splatFile, UploadType.SPLAT);
         splatSuccess = result.success;
-        splatLocationUrl = result.location;
+        splatLocationUrl = result.key;
       }
       setUploadProgress(40);
 
@@ -47,7 +47,7 @@ export default function EditSplatModal({
       if (videoFile.size > 0) {
         const result = await handleMultipartUpload(videoFile, UploadType.VIDEO);
         videoSuccess = result.success;
-        videoLocationUrl = result.location;
+        videoLocationUrl = result.key;
       }
       setUploadProgress(80);
 

--- a/src/app/(views)/admin/dashboard/modalViews/UploadSplatModal.tsx
+++ b/src/app/(views)/admin/dashboard/modalViews/UploadSplatModal.tsx
@@ -22,29 +22,27 @@ export default function UploadSplatModal({ onSuccess }: UploadSplatModalProps) {
 
       const splatFile = splatPayload.get("splatFile") as File;
       if (!splatFile) throw new Error("No Splat File selected");
-      const { success: splatSuccess, location: splatLocationUrl } =
+      const { success: splatSuccess, key: splatKey } =
         await handleMultipartUpload(splatFile, UploadType.SPLAT);
       setUploadProgress(40);
 
       const videoFile = splatPayload.get("videoFile") as File;
       if (!videoFile) throw new Error("No Video File selected");
-      const { success: videoSuccess, location: videoLocationUrl } =
+      const { success: videoSuccess, key: videoKey } =
         await handleMultipartUpload(videoFile, UploadType.VIDEO);
       setUploadProgress(80);
 
       const splatUploadMetaData: SplatUploadMetaData = {
         name: splatPayload.get("name") as string,
         description: splatPayload.get("description") as string,
-        splatFileUrl: splatLocationUrl,
-        videoFileUrl: videoLocationUrl,
+        splatFileUrl: splatKey,
+        videoFileUrl: videoKey,
       };
 
       const response = await fetch("/api/admin/createNewSplatEntry", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          splatUploadMetaData,
-        }),
+        body: JSON.stringify(splatUploadMetaData), // Remove the wrapper object
       });
       if (!response.ok) {
         throw new Error(

--- a/src/app/(views)/gallery/[id]/page.tsx
+++ b/src/app/(views)/gallery/[id]/page.tsx
@@ -42,9 +42,7 @@ export default function GalleryPage({ params }: { params: { id: string } }) {
     try {
       setLoading(true);
       setError(null);
-      const response = await fetch(
-        `/api/galleries/gallery/${galleryId}/splats`
-      );
+      const response = await fetch(`/api/galleries/gallery/${galleryId}/splats`);
 
       if (!response.ok) {
         throw new Error(`HTTP error! status: ${response.status}`);
@@ -56,28 +54,8 @@ export default function GalleryPage({ params }: { params: { id: string } }) {
         throw new Error("Data is not an array");
       }
 
-      // Extract URLs to sign
-      const urlsToSign = data.map((item) => item.src).filter(Boolean);
-
-      // Sign all URLs in one request
-      const signedResponse = await fetch("/api/s3-presign", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ urls: urlsToSign }),
-      });
-
-      const { signedUrls } = await signedResponse.json();
-
-      // Create URL mapping
-      const urlMap = new Map(urlsToSign.map((url, i) => [url, signedUrls[i]]));
-
-      // Update items with signed URLs
-      const signedSplats = data.map((item) => ({
-        ...item,
-        src: urlMap.get(item.src) || item.src,
-      }));
-
-      setSplats(signedSplats);
+      // Server must return already-signed URLs (src and splatUrl).
+      setSplats(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error");
     } finally {
@@ -86,7 +64,7 @@ export default function GalleryPage({ params }: { params: { id: string } }) {
   };
 
   const handleVideoClick = (item: VideoItem) => {
-    if (item.splatUrl) {
+    if (item.splatKey) {
       router.push(
         `/viewer?${new URLSearchParams({
           id: item.id.toString(),

--- a/src/app/(views)/viewer/components/SplatViewer.tsx
+++ b/src/app/(views)/viewer/components/SplatViewer.tsx
@@ -15,11 +15,16 @@ import { SceneSetup } from "./SceneSetup";
 import * as THREE from "three";
 import { ErrorBoundary } from "react-error-boundary";
 import { InfoPanel } from "./InfoPanel";
-import SceneItem from "../../../lib/definitions/SceneItem";
 
 interface SplatViewerProps {
+  sceneItem: {
+    id: number;
+    name: string;
+    description: string;
+    splatUrl: string;
+    videoUrl: string;
+  } | null;
   onClose: () => void;
-  sceneItem: SceneItem | null;
 }
 
 export default function SplatViewer({ onClose, sceneItem }: SplatViewerProps) {

--- a/src/app/api/admin/createNewSplatEntry/route.ts
+++ b/src/app/api/admin/createNewSplatEntry/route.ts
@@ -1,10 +1,11 @@
 import AuthHandler from "@/src/app/lib/auth/authHandler";
-import { NextResponse } from "next/server";
-import { SplatUploadMetaData } from "@/src/app/lib/definitions/SplatPayload";
 import { addSplatRecordToDB } from "@/src/app/lib/db/splatTableUtils";
+import { SplatUploadMetaData } from "@/src/app/lib/definitions/SplatPayload";
+import { NextResponse } from "next/server";
 
 export async function POST(request: Request) {
   try {
+    // Restore auth check
     const authHandler = new AuthHandler();
     if (!(await authHandler.verifyAuth())) {
       return NextResponse.json(
@@ -13,23 +14,29 @@ export async function POST(request: Request) {
       );
     }
 
-    const body = await request.json(); 
-    const splatUploadMetaData: SplatUploadMetaData = body.splatUploadMetaData;
-    const splatId = await addSplatRecordToDB(splatUploadMetaData);
-
-    if (!splatId) {
-      throw new Error("Unable to fetch inserted Id");
+    const splatUploadMetaData: SplatUploadMetaData = await request.json();
+    
+    if (!splatUploadMetaData.splatFileUrl || !splatUploadMetaData.videoFileUrl) {
+      return NextResponse.json(
+        { error: "Missing required file URLs" },
+        { status: 400 }
+      );
     }
 
-    return NextResponse.json(
-      {
-        message: `Splat inserted at id: ${splatId}`,
-      },
-      { status: 200 }
-    );
+    const insertedId = await addSplatRecordToDB(splatUploadMetaData);
+    
+    if (insertedId === null) {
+      return NextResponse.json(
+        { error: "Failed to create splat record" },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({ id: insertedId }, { status: 200 });
   } catch (error) {
+    console.error("Error creating splat entry:", error);
     return NextResponse.json(
-      { error: `Upload Splat Error: ${error}` },
+      { error: "Internal Server Error" },
       { status: 500 }
     );
   }

--- a/src/app/api/admin/galleries/[id]/delete/route.ts
+++ b/src/app/api/admin/galleries/[id]/delete/route.ts
@@ -29,9 +29,9 @@ export async function DELETE(
       );
     }
 
-    if (galleryDetails.thumbnailUrl) {
+    if (galleryDetails.thumbnailKey) {
       const s3Handler = new S3Handler();
-      await s3Handler.deleteFileWithUrl(galleryDetails.thumbnailUrl);
+      await s3Handler.deleteFileWithUrl(galleryDetails.thumbnailKey);
     }
 
     await deleteGallery(galleryId);

--- a/src/app/api/admin/galleries/[id]/edit/route.ts
+++ b/src/app/api/admin/galleries/[id]/edit/route.ts
@@ -45,7 +45,7 @@ export async function POST(
       ? (formData.get("thumbnail") as File)
       : undefined;
 
-    const oldThumbnailUrl = galleryDetails.thumbnailUrl;
+    const oldThumbnailUrl = galleryDetails.thumbnailKey;
     let newThumbnailUrl: string | null = null;
 
     if (thumbnail && thumbnail.size > 0) {
@@ -57,16 +57,18 @@ export async function POST(
       }`;
 
       const s3Handler = new S3Handler();
-      newThumbnailUrl = await s3Handler.upload(
+      const uploadedKey = await s3Handler.upload(
         filenameWithTimestamp,
         thumbnail,
         S3_BUCKET_ENDPOINTS.thumbnail
       );
+      // S3Handler.upload() now returns the key directly
+      newThumbnailUrl = uploadedKey;
     }
     
     const galleryItem: GalleryItem = {
       ...galleryMeta,
-      thumbnailUrl: newThumbnailUrl !== null ? newThumbnailUrl : oldThumbnailUrl,
+      thumbnailKey: newThumbnailUrl !== null ? newThumbnailUrl : oldThumbnailUrl,
     };
 
     const editedId: number = await editGallery(

--- a/src/app/api/admin/galleries/create/route.ts
+++ b/src/app/api/admin/galleries/create/route.ts
@@ -35,7 +35,7 @@ export async function POST(request: Request) {
         };
       });
 
-    let thumbnailUrl: string | null = null;
+    let thumbnailKey: string | null = null;
 
     if (payload.thumbnail) {
       if (!S3_BUCKET_ENDPOINTS.thumbnail) {
@@ -47,23 +47,25 @@ export async function POST(request: Request) {
       }`;
 
       const s3Handler = new S3Handler();
-      thumbnailUrl = await s3Handler.upload(
+      const uploadedKey = await s3Handler.upload(
         filenameWithTimestamp,
         payload.thumbnail,
         S3_BUCKET_ENDPOINTS.thumbnail
       );
+
+      thumbnailKey = uploadedKey;
     }
 
     const galleryId: number = await createGallery(
       payload.name,
       payload.splatIds,
       payload.description,
-      thumbnailUrl || undefined
+      thumbnailKey || undefined
     );
 
     return NextResponse.json({ message: galleryId }, { status: 200 });
   } catch (error) {
-    console.error('Error in galleries/create:', error);
+    console.error("Error in galleries/create:", error);
     return NextResponse.json(
       { error: `Create Gallery Error: ${error}` },
       { status: 500 }

--- a/src/app/api/admin/uploadSplat/initMultipartUpload/route.ts
+++ b/src/app/api/admin/uploadSplat/initMultipartUpload/route.ts
@@ -1,43 +1,56 @@
+import AuthHandler from "@/src/app/lib/auth/authHandler";
 import S3Handler from "@/src/app/lib/cloud/s3";
+import { S3_BUCKET_ENDPOINTS } from "@/src/app/lib/configs/splatUpload";
+import { MultipartUploadConfig, UploadType } from "@/src/app/lib/definitions/SplatPayload";
 import { NextResponse } from "next/server";
 
-import AuthHandler from "@/src/app/lib/auth/authHandler";
-import { MultipartUploadConfig, UploadType } from "@/src/app/lib/definitions/SplatPayload";
-import { S3_BUCKET_ENDPOINTS } from "@/src/app/lib/configs/splatUpload";
-
 export async function POST(request: Request) {
-    try {
-        const authHandler = new AuthHandler();
-            if (!(await authHandler.verifyAuth())) {
-              return NextResponse.json(
-                { error: "Endpoint accessed without authenticated session." },
-                { status: 403 }
-              );
-            }
-
-        const config: MultipartUploadConfig = await request.json(); 
-        const { fileName, numberOfParts, uploadType } = config;
-
-        if (!fileName || !uploadType || !numberOfParts) {
-            return NextResponse.json({ error: 'Missing required parameters' }, { status: 400 });
-        }
-
-        const bucketEndpoint =  uploadType === UploadType.SPLAT? S3_BUCKET_ENDPOINTS.splat: S3_BUCKET_ENDPOINTS.video;
-        const key = `${bucketEndpoint}${new Date().toISOString()}${fileName}`;
-
-        const s3Handler = new S3Handler();
-        const result = await s3Handler.initiateMultipartUpload(
-            key,
-            numberOfParts,
-        );
-
-        if (!result || !result.presignedUrls) {
-            return NextResponse.json({ error: 'Failed to generate presigned URLs' }, { status: 500 });
-        }
-
-        return NextResponse.json({key:key, presignedUrls: result.presignedUrls, uploadId: result.uploadId });
-    } catch (error) {
-        console.error('Error in initMultipartUpload:', error);
-        return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  try {
+    const authHandler = new AuthHandler();
+    if (!(await authHandler.verifyAuth())) {
+      return NextResponse.json(
+        { error: "Endpoint accessed without authenticated session." },
+        { status: 403 }
+      );
     }
+
+    const config: MultipartUploadConfig = await request.json();
+    
+    if (!config.fileName || !config.numberOfParts || !config.uploadType) {
+      return NextResponse.json(
+        { error: "Missing required parameters" },
+        { status: 400 }
+      );
+    }
+
+    const { fileName, numberOfParts, uploadType } = config;
+    const bucketEndpoint = uploadType === UploadType.SPLAT ? S3_BUCKET_ENDPOINTS.splat : S3_BUCKET_ENDPOINTS.video;
+    
+    // Fix: Use numeric timestamp and clean filename
+    const timestamp = Date.now(); // Use numeric timestamp instead of ISO string
+    const cleanFileName = fileName.replace(/[^a-zA-Z0-9.-]/g, '_'); // Clean filename
+    const key = `${bucketEndpoint}${timestamp}_${cleanFileName}`;
+
+    console.log("Generated S3 key:", key); // Debug log
+    console.log("Bucket endpoint:", bucketEndpoint); // Debug log
+
+    const s3Handler = new S3Handler();
+    const result = await s3Handler.initiateMultipartUpload(key, numberOfParts);
+
+    if (!result || !result.presignedUrls) {
+        return NextResponse.json({ error: 'Failed to generate presigned URLs' }, { status: 500 });
+    }
+
+    return NextResponse.json({
+      key: key, 
+      presignedUrls: result.presignedUrls, 
+      uploadId: result.uploadId 
+    });
+  } catch (error) {
+    console.error("Error initializing multipart upload:", error);
+    return NextResponse.json(
+      { error: "Internal Server Error" },
+      { status: 500 }
+    );
+  }
 }

--- a/src/app/api/fetchSceneDetailsWithID/route.ts
+++ b/src/app/api/fetchSceneDetailsWithID/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import SceneItem from "../../lib/definitions/SceneItem";
 import { getSceneItemById } from "../../lib/db/splatTableUtils";
+import S3Handler from "@/src/app/lib/cloud/s3";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -15,13 +16,30 @@ export async function GET(request: Request) {
     if (!rawId) {
       return NextResponse.json({ error: "Id does not exist" }, { status: 404 });
     }
-      const sceneItem: SceneItem | null = await getSceneItemById(parseInt(rawId));
+    const sceneItem: SceneItem | null = await getSceneItemById(parseInt(rawId));
 
     if (sceneItem === null) {
       return NextResponse.json({ error: "Item not found" }, { status: 404 });
     }
 
-    return NextResponse.json(sceneItem, {
+    // --- Step 1: fetch done above (sceneItem)
+    // --- Step 2: presign splat and video keys (DB stores plain object keys)
+    const s3 = new S3Handler();
+    const [signedSplat, signedVideo] = await Promise.all([
+      sceneItem.splatKey ? s3.getSignedS3Url(sceneItem.splatKey) : null,
+      sceneItem.videoKey ? s3.getSignedS3Url(sceneItem.videoKey) : null,
+    ]);
+
+    // Return response with client-expected property names
+    const out = {
+      id: sceneItem.id,
+      name: sceneItem.name,
+      description: sceneItem.description,
+      splatUrl: signedSplat ?? null,
+      videoUrl: signedVideo ?? null,
+    };
+
+    return NextResponse.json(out, {
       headers: {
         "Cache-Control": "no-store, must-revalidate",
         Pragma: "no-cache",
@@ -29,7 +47,7 @@ export async function GET(request: Request) {
       },
     });
   } catch (error) {
-    console.error("Error fetching video items:", error);
+    console.error("Error fetching SceneItem items:", error);
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 }

--- a/src/app/api/fetchVideoItems/route.ts
+++ b/src/app/api/fetchVideoItems/route.ts
@@ -1,17 +1,45 @@
 import { NextResponse } from "next/server";
 import VideoItem from "../../lib/definitions/VideoItem";
 import { fetchVideoItems } from "../../lib/db/splatTableUtils";
+import S3Handler from "../../lib/cloud/s3";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 
 // app/api/fetchVideoItems/route.ts
-
 export async function GET() {
   try {
     const combinedData: VideoItem[] = await fetchVideoItems();
+    const s3 = new S3Handler();
 
-    return NextResponse.json(combinedData, {
+    const signedItems = await Promise.all(
+      combinedData.map(async (it) => {
+        try {
+          const [signedSrc, signedSplat] = await Promise.all([
+            it.srcKey ? s3.getSignedS3Url(it.srcKey) : null,
+            it.splatKey ? s3.getSignedS3Url(it.splatKey) : null,
+          ]);
+
+          return {
+            id: it.id,
+            name: it.name,
+            src: signedSrc ?? it.srcKey ?? "",
+            splatUrl: signedSplat ?? it.splatKey ?? "",
+          };
+        } catch (signErr) {
+          console.error("Error signing URLs for item", it.id, signErr);
+          // fallback to original DB key values if signing fails
+          return {
+            id: it.id,
+            name: it.name,
+            src: it.srcKey ?? "",
+            splatUrl: it.splatKey ?? "",
+          };
+        }
+      })
+    );
+
+    return NextResponse.json(signedItems, {
       headers: {
         "Cache-Control": "no-store, must-revalidate",
         Pragma: "no-cache",
@@ -19,7 +47,7 @@ export async function GET() {
       },
     });
   } catch (error) {
-    console.error("Error fetching video items:", error);
+    console.error("Error fetching or signing video items:", error);
     return NextResponse.json(
       { error: "Internal Server Error" },
       { status: 500 }

--- a/src/app/api/galleries/gallery/[id]/splats/route.ts
+++ b/src/app/api/galleries/gallery/[id]/splats/route.ts
@@ -1,6 +1,7 @@
 // src/app/api/gallery/[id]/splats/route.ts
 import { NextResponse } from "next/server";
 import { fetchGallerySplats } from "@/src/app/lib/db/galleryTableUtils";
+import S3Handler from "@/src/app/lib/cloud/s3";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
@@ -12,19 +13,41 @@ export async function GET(
   try {
     const galleryId = parseInt(params.id);
     const gallerySplats = await fetchGallerySplats(galleryId);
+    const s3Handler = new S3Handler();
 
-    const formattedSplats = gallerySplats.map((item) => ({
-      id: item.id,
-      name: item.name,
-      src: item.video || "",
-      splatUrl: item.splat || "",
-    }));
+    // Sign the keys from DB and return with VideoItem-compatible property names
+    const signedSplats = await Promise.all(
+      gallerySplats.map(async (splat) => {
+        try {
+          const [signedVideo, signedSplat] = await Promise.all([
+            splat.videoKey ? s3Handler.getSignedS3Url(splat.videoKey) : null,
+            splat.splatKey ? s3Handler.getSignedS3Url(splat.splatKey) : null,
+          ]);
 
-    return NextResponse.json(formattedSplats, {
+          return {
+            id: splat.id,
+            name: splat.name,
+            // Return as VideoItem-compatible property names (what VideoCard expects)
+            srcKey: signedVideo ?? splat.videoKey ?? "",
+            splatKey: signedSplat ?? splat.splatKey ?? "",
+          };
+        } catch (signErr) {
+          console.error("Error signing URLs for splat", splat.id, signErr);
+          return {
+            id: splat.id,
+            name: splat.name,
+            srcKey: splat.videoKey ?? "",
+            splatKey: splat.splatKey ?? "",
+          };
+        }
+      })
+    );
+
+    return NextResponse.json(signedSplats, {
       headers: {
         "Cache-Control": "no-store, must-revalidate",
-        "Pragma": "no-cache",
-        "Expires": "0",
+        Pragma: "no-cache",
+        Expires: "0",
       },
     });
   } catch (error) {

--- a/src/app/components/GalleryCard.tsx
+++ b/src/app/components/GalleryCard.tsx
@@ -16,10 +16,10 @@ export default function GalleryCard({ gallery, onClick }: Props) {
                      hover:shadow-xl transition-shadow duration-300
                      transform hover:scale-105 transition-transform"
     >
-      {gallery.thumbnailUrl && (
+      {gallery.thumbnailKey && (
         <div className="w-full h-48 relative">
           <Image
-            src={gallery.thumbnailUrl}
+            src={gallery.thumbnailKey}
             alt={gallery.name}
             fill
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"

--- a/src/app/components/VideoCard.tsx
+++ b/src/app/components/VideoCard.tsx
@@ -47,7 +47,7 @@ export default function VideoCard({ item, onClick }: VideoItemProps) {
     e.preventDefault();
     e.stopPropagation();
     
-    if (item.splatUrl) {
+    if (item.splatKey) {
       onClick(item);
     }
   };
@@ -68,7 +68,7 @@ export default function VideoCard({ item, onClick }: VideoItemProps) {
           isLoaded ? 'block' : 'hidden'
         }`}
         onLoadedData={handleVideoLoad}
-        src={item.src}
+        src={item.srcKey}
         playsInline
         muted
         loop

--- a/src/app/lib/cloud/s3.ts
+++ b/src/app/lib/cloud/s3.ts
@@ -73,14 +73,10 @@ export default class S3Handler {
           Body: fileBlob,
         },
       });
+      
       return await upload.done().then(() => {
-        const outputUrl = buildS3Url(
-          bucketName!,
-          process.env.AWS_REGION!,
-          key
-        );
-
-        return outputUrl;
+        // Return the key instead of the full URL
+        return key;
       });
     } catch (error) {
       console.error("Error during upload:", error);
@@ -139,11 +135,12 @@ export default class S3Handler {
       });
 
       const response = await this.client.send(command);
-      if (!response || !response.Location) {
+      if (!response) {
         throw new Error("Error completing multipart upload");
       }
-      const location = buildS3Url(process.env.AWS_BUCKET_NAME!,process.env.AWS_REGION!, key);
-      return location;
+      
+      // Return the key instead of full URL
+      return key;
     } catch (error) {
       console.error("Error completing multipart upload:", error);
       return null;
@@ -181,8 +178,4 @@ export default class S3Handler {
       return false;
     }
   }
-}
-
-function buildS3Url(bucketName: string,  awsRegion: string, key: string): string{
-  return `https://${bucketName}.s3.${awsRegion}.amazonaws.com/${key}`;
 }

--- a/src/app/lib/cloud/uploadSplatUtils/multiPartUploadUtils.ts
+++ b/src/app/lib/cloud/uploadSplatUtils/multiPartUploadUtils.ts
@@ -71,7 +71,7 @@ export async function completeMultipartUpload(
   key: string,
   uploadId: string,
   parts: CompletedPart[]
-): Promise<{ success: boolean; location: string }> {
+): Promise<{ success: boolean; key: string }> {
   try {
     const response = await fetch(
       "/api/admin/uploadSplat/completeMultipartUpload",
@@ -92,7 +92,7 @@ export async function completeMultipartUpload(
     }
 
     const data = await response.json();
-    return { success: response.ok, location: data.location };
+    return { success: response.ok, key: data.key };
   } catch (error) {
     console.error("Error completing multipart upload:", error);
     throw error;
@@ -102,7 +102,7 @@ export async function completeMultipartUpload(
 export async function handleMultipartUpload(
   file: File,
   uploadType: UploadType
-): Promise<{ success: boolean; location: string }> {
+): Promise<{ success: boolean; key: string }> {
   try {
     const numberOfParts = Math.ceil(file.size / DEFAULT_CHUNK_SIZE);
 
@@ -116,12 +116,12 @@ export async function handleMultipartUpload(
       config
     );
     const parts = await uploadParts(file, presignedUrls, DEFAULT_CHUNK_SIZE);
-    const { success, location } = await completeMultipartUpload(
+    const { success, key: uploadedKey } = await completeMultipartUpload(
       key,
       uploadId,
       parts
     );
-    return { success, location };
+    return { success, key: uploadedKey };
   } catch (error) {
     console.error("Error handling multipart upload:", error);
     throw error;

--- a/src/app/lib/db/schema.ts
+++ b/src/app/lib/db/schema.ts
@@ -4,8 +4,8 @@ import {pgTable, serial, text, timestamp, integer} from 'drizzle-orm/pg-core';
 export const splats = pgTable('splats', {
     id: serial('id').primaryKey(),
     name: text('name'),
-    splat: text('splat'),
-    video: text('video'),
+    splatKey: text('splat_key'),
+    videoKey: text('video_key'),
     createdAt: timestamp('createdAt').defaultNow(),
     updatedAt: timestamp('updatedAt'),
     description: text('description')
@@ -15,7 +15,7 @@ export const galleries = pgTable('galleries', {
     id: serial('id').primaryKey(),
     name: text('name').notNull(),
     description: text('description'),
-    thumbnailUrl: text('thumbnailUrl'),
+    thumbnailKey: text('thumbnail_key'),
     createdAt: timestamp('createdAt').defaultNow(),
     updatedAt: timestamp('updatedAt')
 });

--- a/src/app/lib/db/splatTableUtils.ts
+++ b/src/app/lib/db/splatTableUtils.ts
@@ -8,6 +8,8 @@ import { splats } from "./schema";
 import SceneItem from "../definitions/SceneItem";
 import VideoItem from "../definitions/VideoItem";
 
+type SplatUpdateInput = Partial<typeof splats.$inferInsert>;
+
 export async function addSplatRecordToDB(
   splatUploadMetaData: SplatUploadMetaData
 ): Promise<number | null> {
@@ -16,8 +18,9 @@ export async function addSplatRecordToDB(
     .values({
       name: splatUploadMetaData.name,
       description: splatUploadMetaData.description,
-      splat: splatUploadMetaData.splatFileUrl,
-      video: splatUploadMetaData.videoFileUrl,
+      // store keys in DB columns 'splat' and 'video' via schema mapping
+      splatKey: splatUploadMetaData.splatFileUrl,
+      videoKey: splatUploadMetaData.videoFileUrl,
     })
     .returning({ insertedId: splats.id });
 
@@ -32,8 +35,8 @@ export async function fetchVideoItems(): Promise<VideoItem[]> {
     .select({
       id: splats.id,
       name: splats.name,
-      video: splats.video,
-      splat: splats.splat,
+      videoKey: splats.videoKey,
+      splatKey: splats.splatKey,
     })
     .from(splats)
     .orderBy(splats.id)
@@ -42,8 +45,8 @@ export async function fetchVideoItems(): Promise<VideoItem[]> {
         .map((item) => ({
           id: item.id,
           name: item.name || "",
-          src: item.video || "",
-          splatUrl: item.splat || "",
+          srcKey: item.videoKey || "",
+          splatKey: item.splatKey || "",
         }))
         .sort((a, b) => a.id - b.id);
     });
@@ -57,8 +60,8 @@ export async function getSceneItemById(id: number): Promise<SceneItem | null> {
       id: splats.id,
       name: splats.name,
       description: splats.description,
-      splatUrl: splats.splat,
-      videoUrl: splats.video,
+      splatKey: splats.splatKey,
+      videoKey: splats.videoKey,
     })
     .from(splats)
     .where(eq(splats.id, id))
@@ -67,8 +70,8 @@ export async function getSceneItemById(id: number): Promise<SceneItem | null> {
         id: item.id,
         name: item.name || "",
         description: item.description || "",
-        splatUrl: item.splatUrl || "",
-        videoUrl: item.videoUrl || "",
+        splatKey: item.splatKey || "",
+        videoKey: item.videoKey || "",
       }));
     });
 
@@ -79,25 +82,19 @@ export async function updateRowWithID(
   splatEditMetaData: SplatEditMetaData
 ): Promise<number | null> {
   try {
-    let editSplatQueryParams = {
+    const editSplatQueryParams: SplatUpdateInput = {
       name: splatEditMetaData.name,
       description: splatEditMetaData.description,
     };
 
     if (splatEditMetaData.splatFileUrl) {
-      editSplatQueryParams = Object.assign(editSplatQueryParams, {
-        splat: splatEditMetaData.splatFileUrl,
-      });
+      editSplatQueryParams.splatKey = splatEditMetaData.splatFileUrl;
     }
     if (splatEditMetaData.videoFileUrl) {
-      editSplatQueryParams = Object.assign(editSplatQueryParams, {
-        video: splatEditMetaData.videoFileUrl,
-      });
+      editSplatQueryParams.videoKey = splatEditMetaData.videoFileUrl;
     }
 
-    editSplatQueryParams = Object.assign(editSplatQueryParams, {
-      updatedAt: new Date(),
-    });
+    editSplatQueryParams.updatedAt = new Date();
 
     const result = await db
       .update(splats)
@@ -125,22 +122,32 @@ export async function deleteRowWithID(id: number): Promise<number | null> {
     });
 }
 
-export async function getSplatUrlWithId(id: number): Promise<string | null> {
+// New: get key helpers
+export async function getSplatKeyWithId(id: number): Promise<string | null> {
   const result = await db
-    .select({ splatUrl: splats.splat })
+    .select({ splatKey: splats.splatKey })
     .from(splats)
     .where(eq(splats.id, id))
     .then((data) => data);
 
-  return result.length === 1 ? result[0].splatUrl : null;
+  return result.length === 1 ? result[0].splatKey : null;
+}
+
+export async function getVideoKeyWithId(id: number): Promise<string | null> {
+  const result = await db
+    .select({ videoKey: splats.videoKey })
+    .from(splats)
+    .where(eq(splats.id, id))
+    .then((data) => data);
+
+  return result.length === 1 ? result[0].videoKey : null;
+}
+
+// Keep compatibility wrappers (deprecated names)
+export async function getSplatUrlWithId(id: number): Promise<string | null> {
+  return getSplatKeyWithId(id);
 }
 
 export async function getVideoUrlWithId(id: number): Promise<string | null> {
-  const result = await db
-    .select({ videoUrl: splats.video })
-    .from(splats)
-    .where(eq(splats.id, id))
-    .then((data) => data);
-
-  return result.length === 1 ? result[0].videoUrl : null;
+  return getVideoKeyWithId(id);
 }

--- a/src/app/lib/definitions/GalleryItem.ts
+++ b/src/app/lib/definitions/GalleryItem.ts
@@ -1,21 +1,21 @@
+export interface GallerySplat {
+  id: number;
+  name: string | null;
+  videoKey: string | null;
+  splatKey: string | null;
+}
+
 export interface GalleryItem {
   id: number;
   name: string;
   description: string | null;
-  thumbnailUrl: string | null;
+  thumbnailKey: string | null;
 }
 
 export interface GalleryDetails {
   name: string;
   description: string | null;
 }
-
-export type GallerySplat = {
-  id: number;
-  name: string | null;
-  video: string | null;
-  splat: string | null;
-};
 
 export type GalleryMeta = {
   id: number;

--- a/src/app/lib/definitions/SceneItem.ts
+++ b/src/app/lib/definitions/SceneItem.ts
@@ -2,6 +2,7 @@ export default interface SceneItem {
   id: number;
   name: string | null;
   description: string | null;
-  splatUrl: string | null;
-  videoUrl: string | null;
+  // DB stores keys
+  splatKey: string | null;
+  videoKey: string | null;
 }

--- a/src/app/lib/definitions/VideoItem.ts
+++ b/src/app/lib/definitions/VideoItem.ts
@@ -1,6 +1,7 @@
 export default interface VideoItem {
   id: number;
   name: string;
-  src: string;
-  splatUrl: string;
+  // store keys (not signed URLs) in DB layer naming
+  srcKey: string;
+  splatKey: string;
 }

--- a/src/drizzle/0004_medical_trish_tilby.sql
+++ b/src/drizzle/0004_medical_trish_tilby.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "galleries" RENAME COLUMN "thumbnailUrl" TO "thumbnail_key";--> statement-breakpoint
+ALTER TABLE "splats" RENAME COLUMN "splat" TO "splat_key";--> statement-breakpoint
+ALTER TABLE "splats" RENAME COLUMN "video" TO "video_key";

--- a/src/drizzle/meta/0004_snapshot.json
+++ b/src/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,182 @@
+{
+  "id": "6af83c98-90b6-4854-a257-529b57e1b768",
+  "prevId": "2bc53ef6-b6d2-42e0-967e-027195856579",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.galleries": {
+      "name": "galleries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "thumbnail_key": {
+          "name": "thumbnail_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.splats": {
+      "name": "splats",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "splat_key": {
+          "name": "splat_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "video_key": {
+          "name": "video_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updatedAt": {
+          "name": "updatedAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public.splats_to_galleries": {
+      "name": "splats_to_galleries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "splat_id": {
+          "name": "splat_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "gallery_id": {
+          "name": "gallery_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "splats_to_galleries_splat_id_splats_id_fk": {
+          "name": "splats_to_galleries_splat_id_splats_id_fk",
+          "tableFrom": "splats_to_galleries",
+          "tableTo": "splats",
+          "columnsFrom": [
+            "splat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "splats_to_galleries_gallery_id_galleries_id_fk": {
+          "name": "splats_to_galleries_gallery_id_galleries_id_fk",
+          "tableFrom": "splats_to_galleries",
+          "tableTo": "galleries",
+          "columnsFrom": [
+            "gallery_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/drizzle/meta/_journal.json
+++ b/src/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1736695927282,
       "tag": "0003_messy_mandarin",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1755819223042,
+      "tag": "0004_medical_trish_tilby",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
* [update] Bump package versions in package-lock.json for dependencies

* [update] Bump version of caniuse-lite to 1.0.30001736 in package-lock.json

* [update] Refactor video and gallery data fetching to use S3 for presigned URLs

* [refactor] Update upload response handling to use 'key' instead of 'location' for S3 uploads; remove unused buildS3Url function; enhance updateRowWithID function with type safety

* [update] Clarify asset storage details in README to specify that S3 keys will be stored for dynamic URL signing and easier migration

* corrected changelog