### PR TITLE
Add Gaussian Splatting visualization features

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,12 @@
 // next.config.mjs
+
+// Validate required AWS environment variables at build time
+if (!process.env.AWS_BUCKET_NAME || !process.env.AWS_REGION) {
+  throw new Error(
+    'Missing required AWS environment variables: AWS_BUCKET_NAME and AWS_REGION must be set for image optimization to work correctly.'
+  );
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,7 +5,7 @@ const nextConfig = {
     remotePatterns: [
     {
       protocol: "https",
-      hostname: "gaussian-galleria-assets.s3.us-east-2.amazonaws.com",
+      hostname: `${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com`,
       pathname: "/**",
     }],
   },


### PR DESCRIPTION
….mjs

Replace hardcoded S3 bucket hostname with AWS_BUCKET_NAME and AWS_REGION environment variables to improve deployment flexibility and security.

Fixes #60

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `next.config.mjs` to remove a hardcoded S3 hostname and enforce required AWS configuration.
> 
> - Replace static S3 host in `images.remotePatterns` with `${process.env.AWS_BUCKET_NAME}.s3.${process.env.AWS_REGION}.amazonaws.com`
> - Add build-time check that `AWS_BUCKET_NAME` and `AWS_REGION` are set, throwing an error if missing
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8511121fae1b8d5edd64837a7b615ab42552fa5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Image loading now derives the remote hostname from AWS_REGION and AWS_BUCKET_NAME environment variables.
  * Added build-time validation that fails the build if AWS_REGION or AWS_BUCKET_NAME are not set.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->